### PR TITLE
Add lambert beer law option

### DIFF
--- a/odToConcentration.py
+++ b/odToConcentration.py
@@ -1,0 +1,15 @@
+# this scipt implements a methods to convert optical density (OD) reading to concentration
+
+def lambert_beer_law(od_measurement , extinction_coefficient, path_length):
+    """
+    Convert optical density (OD) measurement to concentration using the Lambert-Beer law.
+    Parameters:
+    od_measurement (float): The optical density measurement.
+    extinction_coefficient (float): The molar extinction coefficient
+    path_length (float): The path length of the cuvette.
+    Returns:
+    float: The concentration.
+
+    """
+    
+    return od_measurement  / ((extinction_coefficient * path_length))


### PR DESCRIPTION
This pull request introduces a new script, `odToConcentration.py`, which provides a function to convert optical density (OD) readings to concentration using the Lambert-Beer law.

New functionality:

* Added the `lambert_beer_law` function to calculate concentration from OD measurements, extinction coefficient, and path length, with a clear docstring explaining parameters and return value.
* Created a new script file `odToConcentration.py` to house this conversion utility.